### PR TITLE
Fix typo in railscasts.vim

### DIFF
--- a/colors/railscasts.vim
+++ b/colors/railscasts.vim
@@ -122,7 +122,7 @@ hi link htmlEndTag           xmlEndTag
 hi xmlTag                    guifg=#E8BF6A
 hi xmlTagName                guifg=#E8BF6A
 hi xmlEndTag                 guifg=#E8BF6A
-t rubyClass                 guifg=#FFFFFF ctermfg=15
+hi rubyClass                 guifg=#FFFFFF ctermfg=15
 highlight rubyConstant              guifg=#DA4939 ctermfg=167
 highlight rubyInstanceVariable      guifg=#D0D0FF ctermfg=189
 highlight rubyInterpolation         guifg=#519F50 ctermfg=107


### PR DESCRIPTION
Trying to use the railscasts colorscheme throws an `E14: Invalid address` error on line 125. This PR corrects that typo.

Thanks!
-Matt
