### PR TITLE
Fix an error in codeschool.vim

### DIFF
--- a/colors/codeschool.vim
+++ b/colors/codeschool.vim
@@ -9,7 +9,7 @@ if exists("syntax_on")
   syntax reset
 endif
 
-let g:colors_name = "Code School 3"
+let g:colors_name = "codeschool"
 
 hi Cursor ctermfg=16 ctermbg=145 cterm=NONE guifg=#182227 guibg=#9ea7a6 gui=NONE
 hi Visual ctermfg=NONE ctermbg=59 cterm=NONE guifg=NONE guibg=#3f4b52 gui=NONE


### PR DESCRIPTION
g:colors_name should point to a valid color scheme file.  Fixing.

`Error detected while processing /Applications/MacVim.app/Contents/Resources/vim/runtime/syntax/synload.vim:
line   19:
E185: Cannot find color scheme 'Code School 3'`
