### PR TITLE
Vundle uses "Plugins" now and not "Bundles"

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ if you [use vim + pathogen](http://vimcasts.org/episodes/synchronizing-plugins-w
 if you [use vim + vundle](https://github.com/gmarik/vundle)
 
     " add to .vimrc
-    Bundle 'flazz/vim-colorschemes'
-    :BundleInstall
+    Plugin 'flazz/vim-colorschemes'
+    :PluginInstall
 
 if you aren't so clever just get all the files in `colors/*.vim` into
   `~/.vim/colors`


### PR DESCRIPTION
Change the README to reflect the Vundle change from "Bundles" to "Plugins" as of v0.10.2.
