### PR TITLE
Dont change statusline in af.vim

### DIFF
--- a/colors/af.vim
+++ b/colors/af.vim
@@ -20,7 +20,6 @@ hi User2 guibg=darkblue guifg=lightblue
 hi User3 guibg=darkblue guifg=red
 hi User4 guibg=darkblue guifg=cyan
 hi User5 guibg=darkblue guifg=lightgreen
-set statusline=%<%1*===\ %5*%f%1*%(\ ===\ %4*%h%1*%)%(\ ===\ %4*%m%1*%)%(\ ===\ %4*%r%1*%)\ ===%====\ %2*%b(0x%B)%1*\ ===\ %3*%l,%c%V%1*\ ===\ %5*%P%1*\ ===%0* laststatus=2
 
 
 hi Normal		guifg=#dfdfdf	guibg=#000000


### PR DESCRIPTION
I really don't like that, especially when I'm just previewing colorschemes.