### PR TITLE
Change URLs to https version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ Installation
 Basic install - very simple (*nix or cygwin install)
 
     mkdir ~/.vim
-    git clone git@github.com:dgvigil/vim-colorschemes.git ~/.vim
+    git clone https://github.com/flazz/vim-colorschemes.git ~/.vim
 
 if you [use vim + pathogen](http://vimcasts.org/episodes/synchronizing-plugins-with-git-submodules-and-pathogen/)
 
     cd ~/.vim
-    git submodule add git@github.com:flazz/vim-colorschemes.git bundle/colorschemes
+    git submodule add https://github.com/flazz/vim-colorschemes.git bundle/colorschemes
 
 if you [use vim + vundle](https://github.com/gmarik/vundle)
 


### PR DESCRIPTION
When I try to do:

```
git clone git@github.com:dgvigil/vim-colorschemes.git
```

I get:

```
Cloning into 'vim-colorschemes'...
Warning: Permanently added the RSA host key for IP address '192.30.252.131' to the list of known hosts.
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
```

Solution:

```
git clone https://github.com/flazz/vim-colorschemes.git
```

(Could change back to dgvigil's repo if you want, but seems to make more sense for it to be flazz's)
