### PR TITLE
Adding vimcolor theme retrieval script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.swp
+*.un~
+repos/

--- a/retrieve_vimcolor_themes.rb
+++ b/retrieve_vimcolor_themes.rb
@@ -8,6 +8,19 @@ base_url = "http://vimcolors.com/api/colorschemes"
 FileUtils.mkdir_p "repos"
 Dir.chdir "repos"
 
+def clone_repo(github_path)
+  pid = Process.spawn("git clone git@github.com:#{github_path}")
+
+  begin
+    Timeout.timeout(15) do
+      Process.wait(pid)
+    end
+  rescue Timeout::Error
+    puts 'Canceling clone, taking too long'
+    Process.kill('TERM', pid)
+  end
+end
+
 # Get up to 20 pages of colorschemes
 (1..20).each do |i|
   json = JSON.parse(open("#{base_url}?page=#{i}").read)
@@ -18,8 +31,12 @@ Dir.chdir "repos"
   # For each colorscheme, clone the git repo
   json["colorschemes"].each do |colorscheme|
     github_repo = colorscheme["github_repo"]["address"]
+    begin
     uri = URI(github_repo)
-    system("git clone git@github.com:#{uri.path}")
+    clone_repo(uri.path)
+    rescue URI::InvalidURIError
+      # Ignore poorly formatted URIs. Go to next.
+    end
   end
   sleep 1
 end

--- a/retrieve_vimcolor_themes.rb
+++ b/retrieve_vimcolor_themes.rb
@@ -1,0 +1,27 @@
+require 'json'
+require 'open-uri'
+require 'fileutils'
+
+base_url = "http://vimcolors.com/api/colorschemes"
+
+FileUtils.mkdir_p "repos"
+Dir.chdir "repos"
+
+# Get up to 20 pages of colorschemes
+(1..20).each do |i|
+  json = JSON.parse(open("#{base_url}?page=#{i}").read)
+
+  # Quit if at end of the list
+  break if json["colorschemes"].nil?
+
+  # For each colorscheme, clone the git repo
+  json["colorschemes"].each do |colorscheme|
+    github_repo = colorscheme["github_repo"]["address"]
+    system("git clone #{github_repo}")
+  end
+  sleep 1
+end
+
+# Copy files into the colors directory
+Dir.chdir ".."
+system("cp repos/*/colors/*.vim colors/")

--- a/retrieve_vimcolor_themes.rb
+++ b/retrieve_vimcolor_themes.rb
@@ -1,6 +1,7 @@
 require 'json'
 require 'open-uri'
 require 'fileutils'
+require 'uri'
 
 base_url = "http://vimcolors.com/api/colorschemes"
 
@@ -17,7 +18,8 @@ Dir.chdir "repos"
   # For each colorscheme, clone the git repo
   json["colorschemes"].each do |colorscheme|
     github_repo = colorscheme["github_repo"]["address"]
-    system("git clone #{github_repo}")
+    uri = URI(github_repo)
+    system("git clone git@github.com:#{uri.path}")
   end
   sleep 1
 end


### PR DESCRIPTION
Execute with ```ruby retrieve_vimcolor_themes.rb```

Note: some of the repos seem to have been marked private, so you may be prompted for a username / password a few times.  You can enter blank data to skip these repos.  I couldn't figure out a way to automate this abort, unfortunately.