### PR TITLE
Change colors_name variable to codeschool for codeschool theme

### DIFF
--- a/colors/codeschool.vim
+++ b/colors/codeschool.vim
@@ -9,7 +9,7 @@ if exists("syntax_on")
   syntax reset
 endif
 
-let g:colors_name = "Code School 3"
+let g:colors_name = "codeschool"
 
 hi Cursor ctermfg=16 ctermbg=145 cterm=NONE guifg=#182227 guibg=#9ea7a6 gui=NONE
 hi Visual ctermfg=NONE ctermbg=59 cterm=NONE guifg=NONE guibg=#3f4b52 gui=NONE


### PR DESCRIPTION
I guess MacVim expects this variable to be the same as the filename. 

```
Error detected while processing /usr/local/Cellar/macvim/HEAD/MacVim.app/Contents/Resources/vim/runtime/syntax/synload.vim:5 - 
line   19:
E185: Cannot find color scheme 'Code School 3'
```