### PR TITLE
do not allow visualstudio.vim change the font

### DIFF
--- a/colors/visualstudio.vim
+++ b/colors/visualstudio.vim
@@ -88,5 +88,5 @@ hi DiffText     guifg=NONE      guibg=#f0c8c8   gui=bold
 hi DiffAdd      guifg=NONE      guibg=#c0e0d0   gui=bold
 hi DiffDelete   guifg=NONE      guibg=#f0e0b0   gui=bold
 
-set guifont=Consolas\ for\ Powerline\ FixedD\ 11
+" set guifont=Consolas\ for\ Powerline\ FixedD\ 11
 


### PR DESCRIPTION
The color scheme should not change the font
and if I don't have the font installed
in linux(ubuntu 14.04), I get very ugly default font
in Windows(win8.1), gvim would crash.