### PR TITLE
Changed monokai to Monokai to keep consistency

### DIFF
--- a/colors/Monokai.vim
+++ b/colors/Monokai.vim
@@ -9,7 +9,7 @@ if exists("syntax_on")
 endif
 
 set t_Co=256
-let g:colors_name = "monokai"
+let g:colors_name = "Monokai"
 
 hi Cursor ctermfg=235 ctermbg=231 cterm=NONE guifg=#272822 guibg=#f8f8f0 gui=NONE
 hi Visual ctermfg=NONE ctermbg=59 cterm=NONE guifg=NONE guibg=#49483e gui=NONE


### PR DESCRIPTION
to keep consistency for downstream plugins, i suggest having "Monokai" all situations instead of "monokai" OR renaming file to "monokai" instead of "Monokai"