### PR TITLE
fix(calmar256): correct dark theme colors name

### DIFF
--- a/colors/calmar256-dark.vim
+++ b/colors/calmar256-dark.vim
@@ -25,7 +25,7 @@ if exists("syntax_on")
     syntax reset
 endif
 
-let g:colors_name = "calmar256"
+let g:colors_name = "calmar256-dark"
 
 let s:save_cpo = &cpo
 set cpo&vim


### PR DESCRIPTION
Fixes vim startup error when using `colorscheme calmar256-dark` in `.vimrc`