### PR TITLE
delete guifont

### DIFF
--- a/colors/visualstudio.vim
+++ b/colors/visualstudio.vim
@@ -87,6 +87,3 @@ hi DiffChange   guifg=NONE      guibg=#e0e0e0   gui=bold
 hi DiffText     guifg=NONE      guibg=#f0c8c8   gui=bold
 hi DiffAdd      guifg=NONE      guibg=#c0e0d0   gui=bold
 hi DiffDelete   guifg=NONE      guibg=#f0e0b0   gui=bold
-
-set guifont=Consolas\ for\ Powerline\ FixedD\ 11
-


### PR DESCRIPTION
Because it can not ensure every one has this font. In fact, if you dont has this font, it will result an error. Even if you wanna use a kind of font which is as same as visual studio, you should use "set guifont=Consolas_NF:h10:cANSI:qDRAFT". Because nerd-fonts have substitute powerfonts.